### PR TITLE
[Discussion] Use MD5 instead of GetHashCode

### DIFF
--- a/TeamCoding.Shared/Extensions/StringExtensions.cs
+++ b/TeamCoding.Shared/Extensions/StringExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TeamCoding.Interfaces.Extensions
+{
+    public static class StringExtensions
+    {
+        public static int ToIntegerCode(this string str, bool ignoreCase = false)
+        {
+            using (var md5provider = new MD5CryptoServiceProvider())
+            {
+                if (ignoreCase)
+                    str = str.ToLowerInvariant();
+
+                var bytes = md5provider.ComputeHash(new UTF8Encoding().GetBytes(str));
+                var integer = BitConverter.ToInt32(bytes, 0);
+                return integer;
+            }
+        }
+    }
+}

--- a/TeamCoding.Shared/TeamCoding.Shared.csproj
+++ b/TeamCoding.Shared/TeamCoding.Shared.csproj
@@ -75,6 +75,7 @@
     <Compile Include="Documents\SourceControlRepositories\ISourceControlRepository.cs" />
     <Compile Include="Extensions\DictionaryExtensions.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />
+    <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="IdentityManagement\IUserIdentity.cs" />
     <Compile Include="IntArrayEqualityComparer.cs" />
     <Compile Include="ITeamCodingPackageProvider.cs" />

--- a/TeamCoding.v14/Documents/CaretInfoProvider.cs
+++ b/TeamCoding.v14/Documents/CaretInfoProvider.cs
@@ -21,7 +21,13 @@ namespace TeamCoding.Documents
             {
                 return null;
             }
+
             var syntaxRoot = await document.GetSyntaxRootAsync();
+            if (syntaxRoot == null)
+            {
+                return null;
+            }
+
             var caretToken = syntaxRoot.FindToken(snapshotPoint);
             int[] memberHashCodes = null;
             IEnumerable<SyntaxNode> memberNodes = null;

--- a/TeamCoding.v14/Extensions/SyntaxNodeExtensions.cs
+++ b/TeamCoding.v14/Extensions/SyntaxNodeExtensions.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using TeamCoding.Interfaces.Extensions;
 
 namespace TeamCoding.Extensions
 {
@@ -115,11 +116,11 @@ namespace TeamCoding.Extensions
 
             var name = syntaxNode.GetIdentifyingString();
 
-            var identityHash = name == null ? 0 : syntaxNode is VisualBasicSyntaxNode ? StringComparer.OrdinalIgnoreCase.GetHashCode(name) : StringComparer.Ordinal.GetHashCode(name);
+            var identityHash = name == null ? 0 : name.ToIntegerCode(syntaxNode is VisualBasicSyntaxNode);
 
             if (!(syntaxNode is ICompilationUnitSyntax) && (identityHash == 0 || syntaxNode.ChildNodes().Count() == 0))
             {
-                identityHash = syntaxNode.ToString().GetHashCode();
+                identityHash = syntaxNode.ToString().ToIntegerCode();
             }
 
             SyntaxNodeHashCache.Add(syntaxNode, identityHash);

--- a/TeamCoding/Documents/RemotelyAccessedDocumentData.cs
+++ b/TeamCoding/Documents/RemotelyAccessedDocumentData.cs
@@ -19,7 +19,10 @@ namespace TeamCoding.Documents
         {
             var hash = 17;
             hash = hash * 31 + Repository.GetHashCode();
-            hash = hash * 31 + RepositoryBranch.GetHashCode();
+
+            if (!string.IsNullOrEmpty(RepositoryBranch))
+                hash = hash * 31 + RepositoryBranch.GetHashCode();
+
             hash = hash * 31 + IdeUserIdentity.GetHashCode();
             hash = hash * 31 + BeingEdited.GetHashCode();
             hash = hash * 31 + HasFocus.GetHashCode();

--- a/TeamCoding/VisualStudio/TextAdornment/TextAdornment.cs
+++ b/TeamCoding/VisualStudio/TextAdornment/TextAdornment.cs
@@ -31,8 +31,8 @@ namespace TeamCoding.VisualStudio.TextAdornment
         private readonly Dictionary<string, Queue<FrameworkElement>> UserAvatars = new Dictionary<string, Queue<FrameworkElement>>();
         public TextAdornment(IWpfTextView view)
         {
-            OpenFilesFilter = of => of.Repository == RepoDocument.RepoUrl &&
-                                    of.RelativePath == RepoDocument.RelativePath &&
+            OpenFilesFilter = of => of.Repository.Equals(RepoDocument.RepoUrl, StringComparison.OrdinalIgnoreCase) &&
+                                    of.RelativePath.Equals(RepoDocument.RelativePath, StringComparison.OrdinalIgnoreCase) &&
                                     of.RepositoryBranch == RepoDocument.RepoBranch &&
                                     of.CaretPositionInfo != null;
 


### PR DESCRIPTION
We've got users spread across different locales, and we're not sure if this is the reason but we can't see the individual carets for where these users are. They can see their own, and we can see ours. The TeamCoding Overview window shows the names of the files that _all_ users have open (so we've ruled it out being a configuration problem). According to the [MSDN docs](https://msdn.microsoft.com/en-us/library/system.string.gethashcode(v=vs.110).aspx), GetHashCode shouldn't be relied upon beyond AppDomain boundaries, so I've put together an implementation that uses a truncated MD5 calculation instead.

I've not thoroughly tested this yet, so don't merge it in, but wanted to run it by you first to see if you had any objects to it. Obviously there'll be a little more overhead in terms of performance, but hopefully not a noticeable difference.