### PR TITLE
Allow branch filter to be ignored

### DIFF
--- a/TeamCoding/Options/OptionPageGrid.cs
+++ b/TeamCoding/Options/OptionPageGrid.cs
@@ -19,6 +19,7 @@ namespace TeamCoding.Options
         public UserSettings.UserDisplaySetting UserCodeDisplay { get; set; } = UserSettings.DefaultUserCodeDisplay;
         public UserSettings.UserDisplaySetting UserTabDisplay { get; set; } = UserSettings.DefaultUserTabDisplay;
         public bool ShowSelf { get; set; } = UserSettings.DefaultShowSelf;
+        public bool ShowAllBranches { get; set; } = UserSettings.DefaultShowAllBranches;
         public string FileBasedPersisterPath { get; set; } = SharedSettings.DefaultFileBasedPersisterPath;
         public string RedisServer { get; set; } = SharedSettings.DefaultRedisServer;
         public string SlackToken { get; set; } = SharedSettings.DefaultSlackToken;

--- a/TeamCoding/Options/OptionsPage.xaml
+++ b/TeamCoding/Options/OptionsPage.xaml
@@ -8,7 +8,7 @@
              d:DesignHeight="500" d:DesignWidth="400">
     <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
         <Grid Height="475">
-            <GroupBox Header="User Settings" Height="152" VerticalAlignment="Top">
+            <GroupBox Header="User Settings" Height="192" VerticalAlignment="Top">
                 <Grid>
                     <TextBox x:Name="txtUsername" Margin="111,10,109,0" Height="26" VerticalAlignment="Top" Text="{Binding Username, Mode=TwoWay}" ToolTip="Set a custom username. Blank to auto-calculate" AutomationProperties.LabeledBy="{Binding ElementName=lblUsername, Mode=OneWay}"/>
                     <Label x:Name="lblUsername" Content="Username" HorizontalAlignment="Left" VerticalAlignment="Top" Target="{Binding ElementName=txtUsername, Mode=OneWay}" Margin="0,10,0,0"/>
@@ -19,9 +19,11 @@
                     <ComboBox x:Name="txtUserCodeDisplay" Margin="111,103,0,0" Height="23" VerticalAlignment="Top" ItemsSource="{Binding Path=UserDisplaySettings}" SelectedValue="{Binding UserCodeDisplay}" ToolTip="How to display other users within code windows." AutomationProperties.LabeledBy="{Binding ElementName=lblUserCodeDisplay, Mode=OneWay}"/>
                     <Label x:Name="lblUserCodeDisplay" Content="User Code Display" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,100,0,0" Target="{Binding ElementName=txtUserCodeDisplay, Mode=OneWay}"/>
                     <CheckBox x:Name="chkShowSelf" Content="{x:Static local:OptionsPage.chkShowSelfCaption}" Margin="0,16,10,0" ToolTip="Show yourself; useful for seeing how you appear, testing out features on your own." IsChecked="{Binding ShowSelf}" Height="15" VerticalAlignment="Top" HorizontalAlignment="Right" Width="94"/>
+                    <Label x:Name="lblShowAllBranches" Content="Show All Branches" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,131,0,0" Target="{Binding ElementName=txtUserCodeDisplay, Mode=OneWay}"/>
+                    <CheckBox x:Name="chkShowAllBranches" Margin="110,138,0,0" ToolTip="Show edits being made on other branches in the project" IsChecked="{Binding ShowAllBranches}" Height="15" VerticalAlignment="Top" HorizontalAlignment="Left"  />
                 </Grid>
             </GroupBox>
-            <GroupBox x:Name="grpPersistence" Header="IDE Sharing" Margin="0,157,0,0" Height="231" VerticalAlignment="Top">
+            <GroupBox x:Name="grpPersistence" Header="IDE Sharing" Margin="0,197,0,0" Height="231" VerticalAlignment="Top">
                 <Grid>
                     <CheckBox x:Name="chkUsingJsonSettings" Content="{x:Static local:OptionsPage.chkUsingJsonSettingsCaption}" HorizontalAlignment="Left" Margin="5,12,0,0" ToolTip="If a TeamCoding.json file is found anywhere in an open solution those settings are used" IsEnabled="False" Height="15" VerticalAlignment="Top"/>
                     <Button x:Name="cmdShowJsonExample" Content="{x:Static local:OptionsPage.cmdShowJsonExampleCaption}" VerticalAlignment="Top" HorizontalAlignment="Right" Width="180" Click="CmdShowJsonExample_Click" ToolTip="Show the contents of an example teamcoding.json file" Margin="0,7,10,0"/>

--- a/TeamCoding/Options/OptionsPage.xaml.cs
+++ b/TeamCoding/Options/OptionsPage.xaml.cs
@@ -25,6 +25,7 @@ namespace TeamCoding.Options
     {
         public const string chkUsingJsonSettingsCaption = "Using " + Settings.TeamCodingConfigFileName;
         public const string chkShowSelfCaption = "Show yourself";
+        public const string chkShowAllBranchesCaption = "Show All Branches";
         public const string cmdShowJsonExampleCaption = "Show example " + Settings.TeamCodingConfigFileName;
 
         private readonly Dictionary<TextBox, CancellationTokenSource> TextBoxIsValidTaskCancelSources = new Dictionary<TextBox, CancellationTokenSource>();

--- a/TeamCoding/Options/UserSettings.cs
+++ b/TeamCoding/Options/UserSettings.cs
@@ -35,6 +35,11 @@ namespace TeamCoding.Options
         public event EventHandler UserTabDisplayChanging { add { UserTabDisplayProperty.Changing += value; } remove { UserTabDisplayProperty.Changing -= value; } }
         private readonly SettingProperty<UserDisplaySetting> UserTabDisplayProperty;
         public const UserDisplaySetting DefaultUserTabDisplay = UserDisplaySetting.Avatar;
+        public bool ShowAllBranches { get { return ShowAllBranchesProperty.Value; } set { ShowAllBranchesProperty.Value = value; } }
+        public event EventHandler ShowAllBranchesChanged { add { ShowAllBranchesProperty.Changed += value; } remove { ShowAllBranchesProperty.Changed -= value; } }
+        public event EventHandler ShowAllBranchesChanging { add { ShowAllBranchesProperty.Changing += value; } remove { ShowAllBranchesProperty.Changing -= value; } }
+        public readonly SettingProperty<bool> ShowAllBranchesProperty;
+        public const bool DefaultShowAllBranches = false;
         public UserSettings()
         {
             ShowSelfProperty = new SettingProperty<bool>(this, null);
@@ -51,6 +56,9 @@ namespace TeamCoding.Options
 
             UserTabDisplayProperty = new SettingProperty<UserDisplaySetting>(this);
             UserTabDisplayProperty.Changed += (s, e) => TeamCodingPackage.Current.Logger.WriteInformation($"Changing setting {nameof(UserTabDisplay)}: {UserTabDisplay}");
+
+            ShowAllBranchesProperty = new SettingProperty<bool>(this, null);
+            ShowAllBranchesProperty.Changed += (s, e) => TeamCodingPackage.Current.Logger.WriteInformation($"Changing setting {nameof(ShowAllBranches)}: {ShowAllBranches}");
         }
     }
 }

--- a/TeamCoding/VisualStudio/TextAdornment/TextAdornment.cs
+++ b/TeamCoding/VisualStudio/TextAdornment/TextAdornment.cs
@@ -36,7 +36,7 @@ namespace TeamCoding.VisualStudio.TextAdornment
             SourceControlRepo = TeamCodingPackage.Current.SourceControlRepo;
             OpenFilesFilter = of => of.Repository.Equals(RepoDocument.RepoUrl, StringComparison.OrdinalIgnoreCase) &&
                                     of.RelativePath.Equals(RepoDocument.RelativePath, StringComparison.OrdinalIgnoreCase) &&
-                                    of.RepositoryBranch == RepoDocument.RepoBranch &&
+                                    (TeamCodingPackage.Current.Settings.UserSettings.ShowAllBranches || of.RepositoryBranch == RepoDocument.RepoBranch) &&
                                     of.CaretPositionInfo != null;
 
             View = view ?? throw new ArgumentNullException(nameof(view));


### PR DESCRIPTION
We make extensive use of feature branches, so being able to see if someone is in the same file on a different branch can be useful. I recognise that this isn't for everyone, so I've put it in as an option and left it as false by default